### PR TITLE
Replace assessment request buttons with Cal.com booking link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
       <ScrollProgress />
       <Header onRequestAssessment={openModal} />
       <main>
-        <Hero onRequestAssessment={openModal} />
+        <Hero />
         <ValueSurface />
         <Problem />
         <Outcomes />
@@ -37,7 +37,7 @@ export default function Home() {
         <WhoItsFor />
         <Pricing onRequestAssessment={openModal} />
         <FAQ />
-        <FinalCTA onRequestAssessment={openModal} />
+        <FinalCTA />
       </main>
       <Footer />
       <AssessmentModal isOpen={modalOpen} onClose={closeModal} />

--- a/src/components/landing/FinalCTA.tsx
+++ b/src/components/landing/FinalCTA.tsx
@@ -61,12 +61,14 @@ export default function FinalCTA({ onRequestAssessment }: FinalCTAProps) {
           transition={{ duration: 0.6, delay: 0.2 }}
           className="mt-10 flex flex-wrap justify-center gap-4"
         >
-          <button
-            onClick={onRequestAssessment}
-            className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-8 py-3.5 text-sm font-medium text-white shadow-sm transition-all hover:bg-[#111C33] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[rgba(46,196,182,0.35)] focus:ring-offset-2 active:scale-[0.97]"
+          <a
+            href="https://cal.com/futurereadystudio/discovery-call"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-8 py-3.5 text-sm font-medium text-white shadow-sm transition-all hover:bg-[#111C33] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[rgba(46,196,182,0.35)] focus:ring-offset-2 active:scale-[0.97] inline-block"
           >
             {finalCtaContent.primaryCta}
-          </button>
+          </a>
           <button
             onClick={scrollToDeliverables}
             className="rounded-xl border border-[var(--color-border-strong)] bg-transparent px-8 py-3.5 text-sm font-medium text-[var(--color-text-primary)] transition-all hover:bg-[rgba(15,23,42,0.04)] active:scale-[0.97]"

--- a/src/components/landing/FinalCTA.tsx
+++ b/src/components/landing/FinalCTA.tsx
@@ -5,11 +5,7 @@ import Section from "./Section";
 import FloatingOrbs from "./FloatingOrbs";
 import { finalCtaContent } from "./copy";
 
-interface FinalCTAProps {
-  onRequestAssessment: () => void;
-}
-
-export default function FinalCTA({ onRequestAssessment }: FinalCTAProps) {
+export default function FinalCTA() {
   const scrollToDeliverables = () => {
     document
       .getElementById("deliverables")

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -4,11 +4,7 @@ import { useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import { heroContent } from "./copy";
 
-interface HeroProps {
-  onRequestAssessment: () => void;
-}
-
-export default function Hero({ onRequestAssessment }: HeroProps) {
+export default function Hero() {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const scrollToDeliverables = () => {

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -95,12 +95,14 @@ export default function Hero({ onRequestAssessment }: HeroProps) {
             transition={{ duration: 0.6, delay: 0.65 }}
             className="mt-10 flex flex-wrap gap-4"
           >
-            <button
-              onClick={onRequestAssessment}
-              className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-6 py-3 text-sm font-medium text-white shadow-sm transition-all hover:bg-[#111C33] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[rgba(46,196,182,0.35)] focus:ring-offset-2 active:scale-[0.97]"
+            <a
+              href="https://cal.com/futurereadystudio/discovery-call"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-6 py-3 text-sm font-medium text-white shadow-sm transition-all hover:bg-[#111C33] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[rgba(46,196,182,0.35)] focus:ring-offset-2 active:scale-[0.97] inline-block"
             >
               {heroContent.primaryCta}
-            </button>
+            </a>
             <button
               onClick={scrollToDeliverables}
               className="rounded-xl border border-[var(--color-border-strong)] bg-transparent px-6 py-3 text-sm font-medium text-[var(--color-text-primary)] transition-all hover:bg-[rgba(15,23,42,0.04)] active:scale-[0.97]"


### PR DESCRIPTION
## Summary
Converted the primary call-to-action buttons in the Hero and FinalCTA components from local onClick handlers to direct links to a Cal.com scheduling page.

## Key Changes
- **Hero.tsx**: Changed primary CTA button from `<button>` with `onRequestAssessment` handler to an `<a>` tag linking to `https://cal.com/futurereadystudio/discovery-call`
- **FinalCTA.tsx**: Applied the same conversion, replacing the button element with an anchor tag pointing to the Cal.com discovery call booking page
- Added `target="_blank"` and `rel="noopener noreferrer"` attributes to open the booking link in a new tab securely
- Added `inline-block` class to anchor tags to maintain button-like styling and layout behavior

## Implementation Details
- The styling and visual appearance remain unchanged - both components retain their original button styling classes
- The conversion maintains all existing Tailwind classes including hover states, focus rings, and active states
- This change removes the dependency on the `onRequestAssessment` callback prop for the primary CTA, streamlining the user flow by directing users directly to the scheduling tool

https://claude.ai/code/session_018iM7BDTCTmGXQAf2UjQF5B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that redirects two CTA buttons to an external Cal.com link and removes their modal-opening callbacks. Main risk is UX/regression around losing the in-page assessment modal entry points and relying on an external URL.
> 
> **Overview**
> Updates the landing page so the primary CTAs in `Hero` and `FinalCTA` no longer open the assessment modal, and instead navigate directly to the Cal.com discovery-call booking URL in a new tab.
> 
> Cleans up the API surface by removing the `onRequestAssessment` prop from those components and their call sites in `src/app/page.tsx`, while preserving the secondary “scroll to deliverables” CTA behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 255e6bb19252c24b2f1733b4fed843988f8542bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->