### PR TITLE
Update all CTA buttons to link to discovery calendarUpdate Header and Pricing CTAs to link to calendar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
     <>
       <GridOverlay show={false} />
       <ScrollProgress />
-      <Header onRequestAssessment={openModal} />
+      <Header />
       <main>
         <Hero />
         <ValueSurface />
@@ -35,7 +35,7 @@ export default function Home() {
         <Outcomes />
         <Process />
         <WhoItsFor />
-        <Pricing onRequestAssessment={openModal} />
+        <Pricing />
         <FAQ />
         <FinalCTA />
       </main>

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -4,11 +4,7 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { siteConfig, footerContent } from "./copy";
 
-interface HeaderProps {
-  onRequestAssessment: () => void;
-}
-
-export default function Header({ onRequestAssessment }: HeaderProps) {
+export default function Header() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -54,12 +50,14 @@ export default function Header({ onRequestAssessment }: HeaderProps) {
               {link.label}
             </a>
           ))}
-          <button
-            onClick={onRequestAssessment}
-            className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-4 py-2 text-[13px] font-medium text-white transition-all hover:bg-[#111C33] hover:shadow-md active:scale-[0.97]"
+          <a
+            href="https://cal.com/futurereadystudio/discovery-call"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-4 py-2 text-[13px] font-medium text-white transition-all hover:bg-[#111C33] hover:shadow-md active:scale-[0.97] inline-block"
           >
             See If It&apos;s a Fit
-          </button>
+          </a>
         </nav>
 
         {/* Mobile menu button */}
@@ -115,15 +113,15 @@ export default function Header({ onRequestAssessment }: HeaderProps) {
                   {link.label}
                 </a>
               ))}
-              <button
-                onClick={() => {
-                  setMobileMenuOpen(false);
-                  onRequestAssessment();
-                }}
-                className="mt-2 w-full rounded-xl bg-[var(--color-text-primary)] px-4 py-2.5 text-sm font-medium text-white"
+              <a
+                href="https://cal.com/futurereadystudio/discovery-call"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMobileMenuOpen(false)}
+                className="mt-2 block w-full rounded-xl bg-[var(--color-text-primary)] px-4 py-2.5 text-sm font-medium text-white text-center"
               >
                 See If It&apos;s a Fit
-              </button>
+              </a>
             </nav>
           </motion.div>
         )}

--- a/src/components/landing/Pricing.tsx
+++ b/src/components/landing/Pricing.tsx
@@ -4,11 +4,7 @@ import { motion } from "framer-motion";
 import Section, { SectionLabel, SectionHeadline } from "./Section";
 import { pricingContent } from "./copy";
 
-interface PricingProps {
-  onRequestAssessment: () => void;
-}
-
-export default function Pricing({ onRequestAssessment }: PricingProps) {
+export default function Pricing() {
   return (
     <Section id="pricing">
       <div className="mx-auto max-w-3xl text-center">
@@ -111,12 +107,14 @@ export default function Pricing({ onRequestAssessment }: PricingProps) {
             </div>
 
             <div className="mt-10 text-center">
-              <button
-                onClick={onRequestAssessment}
-                className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-8 py-3 text-sm font-medium text-white shadow-sm transition-all hover:bg-[#111C33] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[rgba(46,196,182,0.35)] focus:ring-offset-2 active:scale-[0.97]"
+              <a
+                href="https://cal.com/futurereadystudio/discovery-call"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-shine rounded-xl bg-[var(--color-text-primary)] px-8 py-3 text-sm font-medium text-white shadow-sm transition-all hover:bg-[#111C33] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[rgba(46,196,182,0.35)] focus:ring-offset-2 active:scale-[0.97] inline-block"
               >
                 See If It&apos;s a Fit
-              </button>
+              </a>
             </div>
           </div>
         </motion.div>


### PR DESCRIPTION
Replace "See if it's a Fit" buttons in Header (desktop and mobile) and Pricing components to link directly to the calendar instead of opening the assessment modal. Remove unused onRequestAssessment props from both components.

https://claude.ai/code/session_018iM7BDTCTmGXQAf2UjQF5B