### PR TITLE
Fix: pin cffi so Sheet CLI works on fresh cloud sessions

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,7 @@
 google-api-python-client>=2.100.0
 google-auth>=2.23.0
+# cryptography ships with google-auth's service-account signing path and needs
+# the cffi C backend at runtime. On the ephemeral cloud sandbox cffi is not
+# always present, so pin it explicitly — otherwise scripts/sheet.py crashes on
+# a fresh boot with "No module named '_cffi_backend'".
+cffi>=1.15.0


### PR DESCRIPTION
## Problem

`scripts/sheet.py` crashed on a clean sandbox boot with:

```
ModuleNotFoundError: No module named '_cffi_backend'
```

Every FRS routine that touches the Google Sheet (sourcing, posting, outreach — anything LinkedIn) calls `scripts/sheet.py`, so all of them broke. Because the cloud sandbox is ephemeral and rebuilt each session, the failure recurred on **every fresh boot**, which made it look intermittent.

## Root cause

`google-auth`'s service-account signing path pulls in `cryptography`, which needs the `cffi` C backend at runtime. `cffi` was never listed in `scripts/requirements.txt`, so the `SessionStart` hook's `pip install -r scripts/requirements.txt` never installed it. The environment had `cryptography` present but no `cffi`, so the import blew up.

## Fix

Pin `cffi>=1.15.0` in `scripts/requirements.txt` so the boot hook installs it on every session.

## Verification

- `pip install -r scripts/requirements.txt` completes cleanly (exit 0).
- `python3 scripts/sheet.py tabs` and `read`/`count`/`append` all work again (verified against the live Sheet — 1552 prospect rows readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3pWqkVt9TQtCfBCRJXu5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3pWqkVt9TQtCfBCRJXu5i)_